### PR TITLE
Serve SPA assets from dedicated /static mount

### DIFF
--- a/internal/server/router.go
+++ b/internal/server/router.go
@@ -126,19 +126,19 @@ func NewRouter(cfg config.Config, repo *mysql.Repository, authRepo auth.Reposito
 	})
 
 	if cfg.StaticDir != "" {
-		if info, err := os.Stat(cfg.StaticDir); err == nil && info.IsDir() {
-			router.StaticFS("/", gin.Dir(cfg.StaticDir, true))
+               if info, err := os.Stat(cfg.StaticDir); err == nil && info.IsDir() {
+                       router.StaticFS("/static", gin.Dir(cfg.StaticDir, true))
 
-			router.NoRoute(func(c *gin.Context) {
-				if strings.HasPrefix(c.Request.URL.Path, "/api") {
-					c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
-					return
-				}
+                       router.NoRoute(func(c *gin.Context) {
+                               if strings.HasPrefix(c.Request.URL.Path, "/api") {
+                                       c.JSON(http.StatusNotFound, gin.H{"error": "not found"})
+                                       return
+                               }
 
-				c.File(filepath.Join(cfg.StaticDir, "index.html"))
-			})
-		}
-	}
+                               c.File(filepath.Join(cfg.StaticDir, "index.html"))
+                       })
+               }
+       }
 
 	return router
 }

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,5 +3,6 @@ import vue from '@vitejs/plugin-vue'
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  base: '/static/',
   plugins: [vue()],
 })


### PR DESCRIPTION
## Summary
- serve the generated frontend from `/static` to avoid registering a root-level wildcard while keeping the SPA fallback handler
- update the Vite build configuration so built asset URLs resolve through the new static mount path

## Testing
- go list ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3fa5b30b48324acbc5989f9a3161a