### PR TITLE
Fix visit displays and allow optional SKU and visit item fields

### DIFF
--- a/db/migrations/0003_optional_fields.down.sql
+++ b/db/migrations/0003_optional_fields.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE visit_items
+    MODIFY present_quantity INT NOT NULL DEFAULT 0,
+    MODIFY store_quantity INT NOT NULL DEFAULT 0,
+    MODIFY price DECIMAL(10,2) NOT NULL DEFAULT 0;
+
+ALTER TABLE products
+    MODIFY sku VARCHAR(64) NOT NULL;

--- a/db/migrations/0003_optional_fields.up.sql
+++ b/db/migrations/0003_optional_fields.up.sql
@@ -1,0 +1,7 @@
+ALTER TABLE products
+    MODIFY sku VARCHAR(64) NULL;
+
+ALTER TABLE visit_items
+    MODIFY present_quantity INT NULL,
+    MODIFY store_quantity INT NULL,
+    MODIFY price DECIMAL(10,2) NULL;

--- a/internal/storage/mysql/models.go
+++ b/internal/storage/mysql/models.go
@@ -61,10 +61,10 @@ type Category struct {
 
 type Product struct {
 	BaseModel
-	Name       string `json:"name" gorm:"size:255;not null"`
-	SKU        string `json:"sku" gorm:"size:64;uniqueIndex;not null"`
-	BrandID    string `json:"brand_id" gorm:"type:char(26);not null"`
-	CategoryID string `json:"category_id" gorm:"type:char(26);not null"`
+	Name       string  `json:"name" gorm:"size:255;not null"`
+	SKU        *string `json:"sku" gorm:"size:64;uniqueIndex"`
+	BrandID    string  `json:"brand_id" gorm:"type:char(26);not null"`
+	CategoryID string  `json:"category_id" gorm:"type:char(26);not null"`
 }
 
 type Visit struct {
@@ -77,11 +77,11 @@ type Visit struct {
 
 type VisitItem struct {
 	BaseModel
-	VisitID         string  `json:"visit_id" gorm:"type:char(26);not null"`
-	ProductID       string  `json:"product_id" gorm:"type:char(26);not null"`
-	PresentQuantity int     `json:"present_quantity"`
-	StoreQuantity   int     `json:"store_quantity"`
-	Price           float64 `json:"price"`
+	VisitID         string   `json:"visit_id" gorm:"type:char(26);not null"`
+	ProductID       string   `json:"product_id" gorm:"type:char(26);not null"`
+	PresentQuantity *int     `json:"present_quantity"`
+	StoreQuantity   *int     `json:"store_quantity"`
+	Price           *float64 `json:"price"`
 }
 
 type UserToken struct {

--- a/web/src/views/ProductsView.vue
+++ b/web/src/views/ProductsView.vue
@@ -34,7 +34,7 @@
           <label for="name">Название</label>
         </span>
         <span class="p-float-label">
-          <InputText id="sku" v-model="currentItem.sku" required />
+          <InputText id="sku" v-model="currentItem.sku" />
           <label for="sku">SKU</label>
         </span>
         <div>
@@ -78,6 +78,25 @@ import api from '../services/api';
 const brandOptions = ref([]);
 const categoryOptions = ref([]);
 
+const normalizeSku = (value) => {
+  if (value === null || value === undefined) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  return trimmed === '' ? null : trimmed;
+};
+
+const crud = useCrud(
+  '/products',
+  () => ({ name: '', sku: '', brand_id: null, category_id: null }),
+  {
+    preparePayload: (payload) => ({
+      ...payload,
+      sku: normalizeSku(payload.sku),
+    }),
+  }
+);
+
 const {
   items,
   loading,
@@ -89,7 +108,7 @@ const {
   openEdit,
   saveItem,
   deleteItem,
-} = useCrud('/products', () => ({ name: '', sku: '', brand_id: null, category_id: null }));
+} = crud;
 
 const dialogTitle = computed(() =>
   currentItem?.value?.id ? 'Редактирование продукта' : 'Новый продукт'

--- a/web/src/views/VisitsView.vue
+++ b/web/src/views/VisitsView.vue
@@ -7,12 +7,12 @@
     <DataTable :value="items" dataKey="id" :loading="loading" responsiveLayout="scroll">
       <Column header="Пользователь">
         <template #body="{ data }">
-          {{ findLabel(userOptions, data.user_id) }}
+          {{ userLabelById[data.user_id] ?? data.user_id ?? '' }}
         </template>
       </Column>
       <Column header="Торговая точка">
         <template #body="{ data }">
-          {{ findLabel(retailOptions, data.retail_point_id) }}
+          {{ retailLabelById[data.retail_point_id] ?? data.retail_point_id ?? '' }}
         </template>
       </Column>
       <Column field="visited_at" header="Дата посещения">
@@ -82,6 +82,14 @@ import api from '../services/api';
 const userOptions = ref([]);
 const retailOptions = ref([]);
 
+const userLabelById = computed(() =>
+  Object.fromEntries(userOptions.value.map((user) => [user.id, user.name]))
+);
+
+const retailLabelById = computed(() =>
+  Object.fromEntries(retailOptions.value.map((point) => [point.id, point.name]))
+);
+
 const crud = useCrud(
   '/visits',
   () => ({ user_id: null, retail_point_id: null, visited_at: new Date(), notes: '' }),
@@ -106,11 +114,6 @@ const formatDate = (value) => {
     dateStyle: 'medium',
     timeStyle: 'short',
   }).format(date);
-};
-
-const findLabel = (options, value) => {
-  const option = options.value.find((item) => item.id === value);
-  return option ? option.name : value;
 };
 
 const openCreate = () => {


### PR DESCRIPTION
## Summary
- ensure visit and visit item tables resolve related display names reliably
- allow optional SKU and nullable inventory/price fields with backing migration and model updates
- relax frontend validation and payload handling for the new optional fields

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e4022855b083249d41d815877b1160