### PR TITLE
Display categories as tree

### DIFF
--- a/web/src/composables/useCrud.js
+++ b/web/src/composables/useCrud.js
@@ -24,8 +24,8 @@ export function useCrud(endpoint, createDefault, options = {}) {
     }
   };
 
-  const openCreate = () => {
-    currentItem.value = createDefault();
+  const openCreate = (initialValues = {}) => {
+    currentItem.value = { ...createDefault(), ...initialValues };
     dialogVisible.value = true;
   };
 

--- a/web/src/main.js
+++ b/web/src/main.js
@@ -16,6 +16,7 @@ import Toast from 'primevue/toast';
 import Toolbar from 'primevue/toolbar';
 import Divider from 'primevue/divider';
 import InputNumber from 'primevue/inputnumber';
+import Tree from 'primevue/tree';
 
 import Lara from '@primevue/themes/lara';
 import 'primeicons/primeicons.css';
@@ -53,5 +54,6 @@ app.component('Toast', Toast);
 app.component('Toolbar', Toolbar);
 app.component('Divider', Divider);
 app.component('InputNumber', InputNumber);
+app.component('Tree', Tree);
 
 app.mount('#app');


### PR DESCRIPTION
## Summary
- replace the categories table with a hierarchical tree and in-place actions to add, edit, or remove categories
- allow passing initial values when opening the creation dialog and register the PrimeVue Tree component globally

## Testing
- npm --prefix web run build

------
https://chatgpt.com/codex/tasks/task_e_68e4077000ec832494f0efb1a45ce4b9