### PR TITLE
Fix category tree display for items without parent_id

### DIFF
--- a/web/src/views/CategoriesView.vue
+++ b/web/src/views/CategoriesView.vue
@@ -84,9 +84,11 @@ const parentOptions = computed(() => {
   return items.value.filter((category) => category.id !== currentId);
 });
 
+const getParentId = (category) => (category.parent_id ?? null);
+
 const buildTree = (categories, parentId = null) => {
   return categories
-    .filter((category) => category.parent_id === parentId)
+    .filter((category) => getParentId(category) === parentId)
     .sort((a, b) => a.name.localeCompare(b.name))
     .map((category) => ({
       key: String(category.id),


### PR DESCRIPTION
## Summary
- normalize category parent identifiers before building the tree
- ensure root nodes render even when parent_id is missing in the payload

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e409989fb88324957ea40aecb28e65